### PR TITLE
Add license to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name" : "buffers",
     "description" : "Treat a collection of Buffers as a single contiguous partially mutable Buffer.",
-    "version" : "0.1.1",
+    "version" : "0.1.2",
     "repository" : "http://github.com/substack/node-buffers.git",
     "author" : "James Halliday <mail@substack.net> (http://substack.net)",
     "main" : "./index",


### PR DESCRIPTION
Hi! We’re checking licenses before we distribute using [license-checker](https://github.com/davglass/license-checker). Unfortunately, the 0.1.1 version on NPM contains _no_ licensing information (see #9). Could you please publish a patch so it includes the license?